### PR TITLE
First pull request for net-phy-realtek-next

### DIFF
--- a/drivers/net/phy/phy_device.c
+++ b/drivers/net/phy/phy_device.c
@@ -831,6 +831,14 @@ static int get_phy_c45_ids(struct mii_bus *bus, int addr,
 		if (!(devs_in_pkg & (1 << i)))
 			continue;
 
+		/* Realtek PHY's do not support reading from MDIO_MMD_VEND1
+		 * at MDIO_STAT2 or MII_PHYSIDx. It makes them fail.
+		 */
+		if (i == MDIO_MMD_VEND1 && phy_id_compare(
+				c45_ids->device_ids[MDIO_MMD_PMAPMD],
+				0x001cc800, GENMASK(31, 10)))
+			continue;
+
 		if (i == MDIO_MMD_VEND1 || i == MDIO_MMD_VEND2) {
 			/* Probe the "Device Present" bits for the vendor MMDs
 			 * to ignore these if they do not contain IEEE 802.3

--- a/drivers/net/phy/phylink.c
+++ b/drivers/net/phy/phylink.c
@@ -3256,11 +3256,17 @@ static void phylink_sfp_link_up(void *upstream)
 	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_LINK);
 }
 
-/* The Broadcom BCM84881 in the Methode DM7052 is unable to provide a SGMII
- * or 802.3z control word, so inband will not work.
- */
 static bool phylink_phy_no_inband(struct phy_device *phy)
 {
+	/* Inband is disabled for these PHY's */
+	if (phy->is_c45 && (phy->c45_ids.device_ids[1] == 0x001cc838 ||
+			phy_id_compare(phy->c45_ids.device_ids[1],
+					0x001cc840, 0xfffffff0)))
+		return true;
+
+	/* The Broadcom BCM84881 in the Methode DM7052 is unable to provide
+	* a SGMII or 802.3z control word, so inband will not work.
+	*/
 	return phy->is_c45 && phy_id_compare(phy->c45_ids.device_ids[1],
 					     0xae025150, 0xfffffff0);
 }

--- a/drivers/net/phy/realtek.c
+++ b/drivers/net/phy/realtek.c
@@ -88,6 +88,7 @@
 
 #define RTL_GENERIC_PHYID			0x001cc800
 #define RTL_8211FVD_PHYID			0x001cc878
+#define RTL_8221B_VB_CG				0x001cc849
 
 MODULE_DESCRIPTION("Realtek PHY driver");
 MODULE_AUTHOR("Johnson Leung");
@@ -790,6 +791,53 @@ static int rtl8226_match_phy_device(struct phy_device *phydev)
 	       rtlgen_supports_2_5gbps(phydev);
 }
 
+static int rtl8221b_vb_cg_match_phy_device(struct phy_device *phydev)
+{
+	int val;
+	u32 id;
+
+	if (phydev->is_c45) {
+		if (phydev->c45_ids.device_ids[1])
+			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG;
+	} else {
+		if (phydev->phy_id)
+			return phydev->phy_id == RTL_8221B_VB_CG;
+	}
+
+	if (phydev->mdio.bus->read_c45) {
+		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID1);
+		if (val < 0)
+			return 0;
+
+		id = val << 16;
+		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID2);
+		if (val < 0)
+			return 0;
+
+		id |= val;
+	} else {
+		val = phy_read(phydev, MII_PHYSID1);
+		if (val < 0)
+			return 0;
+
+		id = val << 16;
+		val = phy_read(phydev, MII_PHYSID2);
+		if (val < 0)
+			return 0;
+
+		id |= val;
+	}
+
+	if (id != RTL_8221B_VB_CG) return 0;
+
+	if (phydev->is_c45)
+		phydev->c45_ids.device_ids[1] = id;
+	else
+		phydev->phy_id = id;
+
+	return true;
+}
+
 static int rtlgen_resume(struct phy_device *phydev)
 {
 	int ret = genphy_resume(phydev);
@@ -1179,7 +1227,7 @@ static struct phy_driver realtek_drvs[] = {
 		.write_page     = rtl821x_write_page,
 		.soft_reset     = genphy_soft_reset,
 	}, {
-		PHY_ID_MATCH_EXACT(0x001cc849),
+		.match_phy_device = rtl8221b_vb_cg_match_phy_device,
 		.name           = "RTL8221B-VB-CG 2.5Gbps PHY",
 		.get_features   = rtl822x_get_features,
 		.config_init    = rtl8221b_config_init,

--- a/drivers/net/phy/realtek.c
+++ b/drivers/net/phy/realtek.c
@@ -554,16 +554,10 @@ static int rtl8366rb_config_init(struct phy_device *phydev)
 }
 
 /* get actual speed to cover the downshift case */
-static int rtlgen_get_speed(struct phy_device *phydev)
+static int rtlgen_get_speed(struct phy_device *phydev, int val)
 {
-	int val;
-
 	if (!phydev->link)
 		return 0;
-
-	val = phy_read_paged(phydev, 0xa43, 0x12);
-	if (val < 0)
-		return val;
 
 	switch (val & RTLGEN_SPEED_MASK) {
 	case 0x0000:
@@ -593,13 +587,17 @@ static int rtlgen_get_speed(struct phy_device *phydev)
 
 static int rtlgen_read_status(struct phy_device *phydev)
 {
-	int ret;
+	int ret, val;
 
 	ret = genphy_read_status(phydev);
 	if (ret < 0)
 		return ret;
 
-	return rtlgen_get_speed(phydev);
+	val = phy_read_paged(phydev, 0xa43, 0x12);
+	if (val < 0)
+		return val;
+
+	return rtlgen_get_speed(phydev, val);
 }
 
 static int rtlgen_read_mmd(struct phy_device *phydev, int devnum, u16 regnum)

--- a/drivers/net/phy/realtek.c
+++ b/drivers/net/phy/realtek.c
@@ -578,6 +578,9 @@ static int rtlgen_get_speed(struct phy_device *phydev, int val)
 	case 0x0220:
 		phydev->speed = SPEED_5000;
 		break;
+	case 0x0230:
+		phydev->speed = SPEED_1000;
+		break;
 	default:
 		break;
 	}

--- a/drivers/net/phy/sfp.c
+++ b/drivers/net/phy/sfp.c
@@ -363,6 +363,14 @@ static void sfp_fixup_rollball_proto(struct sfp *sfp, unsigned int secs)
 	sfp->module_t_wait = msecs_to_jiffies(secs * 1000);
 }
 
+// For 2.5GBASE-T short-reach modules
+static void sfp_fixup_oem_2_5g(struct sfp *sfp)
+{
+	sfp_fixup_rollball_proto(sfp, 4);
+	sfp->id.base.connector = SFF8024_CONNECTOR_RJ45;
+	sfp->id.base.extended_cc = SFF8024_ECC_2_5GBASE_T;
+}
+
 static void sfp_fixup_fs_10gt(struct sfp *sfp)
 {
 	sfp_fixup_10gbaset_30m(sfp);
@@ -402,23 +410,6 @@ static void sfp_quirk_2500basex(const struct sfp_eeprom_id *id,
 {
 	linkmode_set_bit(ETHTOOL_LINK_MODE_2500baseX_Full_BIT, modes);
 	__set_bit(PHY_INTERFACE_MODE_2500BASEX, interfaces);
-}
-
-static void sfp_quirk_disable_autoneg(const struct sfp_eeprom_id *id,
-				      unsigned long *modes,
-				      unsigned long *interfaces)
-{
-	linkmode_clear_bit(ETHTOOL_LINK_MODE_Autoneg_BIT, modes);
-}
-
-static void sfp_quirk_oem_2_5g(const struct sfp_eeprom_id *id,
-			       unsigned long *modes,
-			       unsigned long *interfaces)
-{
-	/* Copper 2.5G SFP */
-	linkmode_set_bit(ETHTOOL_LINK_MODE_2500baseT_Full_BIT, modes);
-	__set_bit(PHY_INTERFACE_MODE_2500BASEX, interfaces);
-	sfp_quirk_disable_autoneg(id, modes, interfaces);
 }
 
 static void sfp_quirk_ubnt_uf_instant(const struct sfp_eeprom_id *id,
@@ -475,7 +466,7 @@ static const struct sfp_quirk sfp_quirks[] = {
 	SFP_QUIRK_F("Walsun", "HXSX-ATRI-1", sfp_fixup_fs_10gt),
 
 	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
-	SFP_QUIRK_M("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+	SFP_QUIRK_F("OEM", "SFP-2.5G-T", sfp_fixup_oem_2_5g),
 	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
 	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),
 	SFP_QUIRK_F("Turris", "RTSFP-10", sfp_fixup_rollball),


### PR DESCRIPTION
Take a look, it is not enough tested, don't accept yet.

I have changed the code rtl8221b_vb_cg_match_phy_device() a bit to store the id.

The ID is used for matching in phylink_phy_no_inband()

Also reduce the times phy_read_mmd() / phy_read() is being used, i assumed the id on the early 8221b itself equals zero, so only read it when the id == 0. I do not have such a rtl8221b so I do not know if this works.

The rest of the code is pretty straight forward.

I think `genphy_c45_pma_resume(phydev)` can be removed from rtl822x_c45_config_init(), as it will be called later anyway, but I need to test that.